### PR TITLE
chore(msword): add custom modification

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -942,6 +942,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                     text=text,
                     formatting=format,
                     hyperlink=hyperlink,
+                    ilevel=ilevel,
                 )
 
         elif (
@@ -987,6 +988,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                     text=text,
                     formatting=format,
                     hyperlink=hyperlink,
+                    ilevel=ilevel,
                 )
         elif (
             self._prev_numid() == numid
@@ -1016,6 +1018,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                     text=text,
                     formatting=format,
                     hyperlink=hyperlink,
+                    ilevel=ilevel,
                 )
             self.listIter = 0
 
@@ -1039,6 +1042,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                     text=text,
                     formatting=format,
                     hyperlink=hyperlink,
+                    ilevel=ilevel,
                 )
         return
 

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -256,6 +256,8 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
 
             elif drawing_blip:
                 self._handle_pictures(docx_obj, drawing_blip, doc)
+                # To fix anchored image on text. Feature from LibraOffice
+                self._handle_text_elements(element, docx_obj, doc)
             # Check for the sdt containers, like table of contents
             elif tag_name in ["sdt"]:
                 sdt_content = element.find(".//w:sdtContent", namespaces=namespaces)


### PR DESCRIPTION
# Description

This serve as a PR that are forever open. And we only rebase against the `main` branch.

Main changes are:
1. Handle text when there is an image anchored (Libra Office)
2. Certain DOCX have their own tagging. Handle them.
3. Skip TOC
4. Handle situation when numid changed, but did not start a new list